### PR TITLE
Stabilize ConstDefault on array types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc(html_root_url = "http://docs.rs/const-default/0.1.0")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "unstable", feature(const_generics))]
 #![cfg_attr(all(feature = "unstable", feature = "alloc"), feature(const_btree_new))]
 #![cfg_attr(feature = "unstable", allow(incomplete_features))]
 
@@ -181,24 +180,6 @@ impl_tuple! {
     A B C D E F G H I J K L
 }
 
-#[cfg(not(feature = "unstable"))]
-macro_rules! impl_array {
-    ($($len:tt),*) => {
-        $(impl<T: ConstDefault> ConstDefault for [T; $len] {
-            const DEFAULT: Self = [T::DEFAULT; $len];
-        })*
-    };
-}
-
-#[cfg(not(feature = "unstable"))]
-impl_array! {
-    0, 1, 2, 3, 4, 5, 6, 7, 8,
-    9, 10, 11, 12, 13, 14, 15, 16,
-    17, 18, 19, 20, 21, 22, 23, 24,
-    25, 26, 27, 28, 29, 30, 31, 32
-}
-
-#[cfg(feature = "unstable")]
 impl<T: ConstDefault, const N: usize> ConstDefault for [T; N] {
     const DEFAULT: Self = [T::DEFAULT; N];
 }


### PR DESCRIPTION
This used to require const_generics. However, `min_const_generics` is
now stable and is sufficient to implement this feature on stable.