### PR TITLE
Modernize proc. macro codegen for ConstDefault trait derive

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -14,7 +14,11 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
+proc-macro-crate = "1"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", default-features = false, features = ["derive", 
  "parsing", "proc-macro", "printing"] }
+
+[dev-dependencies]
+const-default = { path = "..", features = ["derive"] }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -55,6 +55,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
     }
 }
 
+/// Implements the derive of `#[derive(ConstDefault)]` for struct types.
 fn derive_default(input: TokenStream2) -> Result<TokenStream2, syn::Error> {
     let crate_ident = query_crate_ident()?;
     let input = syn::parse2::<syn::DeriveInput>(input)?;
@@ -85,6 +86,10 @@ fn derive_default(input: TokenStream2) -> Result<TokenStream2, syn::Error> {
 }
 
 /// Queries the dependencies for the derive root crate name and returns the identifier.
+///
+/// # Note
+///
+/// This allows to use crate aliases in `Cargo.toml` files of dependencies.
 fn query_crate_ident() -> Result<TokenStream2, syn::Error> {
     let query = crate_name("const-default").map_err(|error| {
         Error::new(
@@ -105,6 +110,14 @@ fn query_crate_ident() -> Result<TokenStream2, syn::Error> {
 }
 
 /// Generates the `ConstDefault` implementation for `struct` input types.
+///
+/// # Note
+///
+/// The generated code abuses the fact that in Rust struct types can always
+/// be represented with braces and either using identifiers for fields or
+/// raw number literals in case of tuple-structs.
+///
+/// For example `struct Foo(u32)` can be represented as `Foo { 0: 42 }`.
 fn generate_default_impl_struct(
     crate_ident: &TokenStream2,
     data_struct: &syn::DataStruct,


### PR DESCRIPTION
Today I funnily wanted to implement the same trait and derive and later found your crate so I wanted to give back by opening this PR that should ideally improve this already existing solution for the community.

For more information about my own "fork" of the whole solution:
https://github.com/Robbepop/const-default-rs

If you like and merge this I can open some more PRs for some other more minor improvements.
I hope this is appreciated. :)

## What this RP does:

- This PR modernizes the proc. macro codegen for the `ConstDefault` trait derive.
- This fixes some macro hygiene problems.
- Furthermore this now uses `proc-macro-crate` in order to allow for renaming the `ConstDefault` definition and implementation crate.
- Added some minor documentation and example to the proc. macro.