### PR TITLE
add missing assert in derive test

### DIFF
--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -170,6 +170,7 @@ fn struct_of_cell_types_works() {
         field_1: Cell<i32>,
         field_2: RefCell<i32>,
     }
+    assert_eq!(<TestStruct as ConstDefault>::DEFAULT, TestStruct::default());
 }
 
 #[test]


### PR DESCRIPTION
This seems like an oversight since it's done in the other tests.